### PR TITLE
Removed obsolete Authenticate with reqBody argument.

### DIFF
--- a/authenticate.go
+++ b/authenticate.go
@@ -4,11 +4,6 @@ import (
 	"github.com/giantswarm/api-schema"
 )
 
-func (this *Client) Authenticate(userOrMail, password string) (string, error) {
-	userID, err := this.AuthenticateCredentials(userOrMail, password)
-	return userID, Mask(err)
-}
-
 // Authenticate checks that a user with the given username (or email) exists.
 func (this *Client) AuthenticateCredentials(userOrMail, password string) (string, error) {
 	zeroVal := ""


### PR DESCRIPTION
Needed for the implementation of giantswarm/api#14

Required by giantswarm/api#40
