### PR TITLE
Return wrong input error if trying to authenticate with empty email or password

### DIFF
--- a/authenticate.go
+++ b/authenticate.go
@@ -8,6 +8,10 @@ import (
 func (this *Client) AuthenticateCredentials(userOrMail, password string) (string, error) {
 	zeroVal := ""
 
+        if (userOrMail == "" || password == "") {
+          return zeroVal, Mask(ErrWrongInput)
+        }
+
 	payload := map[string]string{
 		"password": password,
 	}


### PR DESCRIPTION
Related to: https://github.com/giantswarm/api/pull/562

Since I don’t want to introduce validation logic in `api`